### PR TITLE
Add S3 mount script and integrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains pre-configured templates and automation scripts to help
 - GPU-optimized configurations
 - Common ML/AI frameworks templates
 - Network and storage configuration helpers
+- Automatic S3 mounting script
 
 ## Usage
 
@@ -53,6 +54,8 @@ ENV_VARIABLES:
 S3__ACCESS_KEY=
 S3__SECRET_KEY=
 S3__ENDPOINT_URL=
+S3_BUCKET=
+S3_MOUNT_POINT=
 ADMIN_USER_NAME=
 ADMIN_USER_PUBKEY=
 ADMIN_USER_SUDO=

--- a/extra_commands
+++ b/extra_commands
@@ -73,5 +73,8 @@ else
     echo "Переменные ADMIN_USER_NAME и ADMIN_USER_PUBKEY не заданы. Пользователь не создан."
 fi
 
+# 3. Attempt to mount S3 storage using provided credentials
+/opt/scripts/mount_s3.sh
+
 echo "--- Контейнер готов к работе. Ожидание подключения... ---"
 '

--- a/mount_s3.sh
+++ b/mount_s3.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUCKET="${S3_BUCKET:-}"   # required bucket name
+MOUNT_POINT="${S3_MOUNT_POINT:-/mnt/s3}"
+ACCESS_KEY="${S3__ACCESS_KEY:-}"
+SECRET_KEY="${S3__SECRET_KEY:-}"
+ENDPOINT="${S3__ENDPOINT_URL:-}"
+
+if [[ -z "$BUCKET" || -z "$ACCESS_KEY" || -z "$SECRET_KEY" || -z "$ENDPOINT" ]]; then
+  echo "S3 mount variables not fully specified. Skipping mount."
+  exit 0
+fi
+
+if ! command -v s3fs >/dev/null 2>&1; then
+  apt-get update && apt-get install -y --no-install-recommends s3fs && rm -rf /var/lib/apt/lists/*
+fi
+
+# credentials file for s3fs
+echo "$ACCESS_KEY:$SECRET_KEY" > /etc/passwd-s3fs
+chmod 600 /etc/passwd-s3fs
+
+mkdir -p "$MOUNT_POINT"
+
+# mount if not already mounted
+if mountpoint -q "$MOUNT_POINT"; then
+  echo "S3 already mounted at $MOUNT_POINT"
+else
+  s3fs "$BUCKET" "$MOUNT_POINT" -o url="$ENDPOINT" -o use_path_request_style -o allow_other -o passwd_file=/etc/passwd-s3fs
+fi
+


### PR DESCRIPTION
## Summary
- add `mount_s3.sh` for automatic mounting of S3 buckets
- call `mount_s3.sh` from the startup commands
- document S3 mount variables and feature in README

## Testing
- `bash -n create_user.sh`
- `bash -n setup_conda_env.sh`
- `bash -n mount_s3.sh`
- `bash -n extra_commands`


------
https://chatgpt.com/codex/tasks/task_b_688ca3a7ecf48321a1fcb4310c41edab