### PR TITLE
Improve FUSE fallback for S3 mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,14 @@ ADMIN_USER_SUDO=
 GITHUB_TOKEN=
 PYTHON_VERSION=3.12
 ```
+
+### S3 Mount Requirements
+
+The `mount_s3.sh` script uses `s3fs` which relies on the FUSE kernel module. Ensure
+your container has access to `/dev/fuse` and that FUSE is enabled on the host.
+When running with Docker, start the container with `--device /dev/fuse --cap-add SYS_ADMIN`
+(or `--privileged`) so the script can successfully mount the bucket.
+
+If FUSE cannot be enabled, the script falls back to copying the bucket with
+`aws s3 sync`. This provides a one-time synchronization but does not create a
+live mount.

--- a/mount_s3.sh
+++ b/mount_s3.sh
@@ -12,8 +12,26 @@ if [[ -z "$BUCKET" || -z "$ACCESS_KEY" || -z "$SECRET_KEY" || -z "$ENDPOINT" ]];
   exit 0
 fi
 
+# ensure s3fs is available
 if ! command -v s3fs >/dev/null 2>&1; then
   apt-get update && apt-get install -y --no-install-recommends s3fs && rm -rf /var/lib/apt/lists/*
+fi
+
+# check that FUSE device exists and try to load module if missing
+if [[ ! -e /dev/fuse ]]; then
+  if command -v modprobe >/dev/null 2>&1; then
+    modprobe fuse 2>/dev/null || true
+  fi
+fi
+
+if [[ ! -e /dev/fuse ]]; then
+  echo "FUSE device /dev/fuse not found. Falling back to 'aws s3 sync'." >&2
+  if ! command -v aws >/dev/null 2>&1; then
+    apt-get update && apt-get install -y --no-install-recommends awscli && rm -rf /var/lib/apt/lists/*
+  fi
+  mkdir -p "$MOUNT_POINT"
+  aws s3 sync "s3://$BUCKET" "$MOUNT_POINT" --endpoint-url "$ENDPOINT"
+  exit 0
 fi
 
 # credentials file for s3fs


### PR DESCRIPTION
## Summary
- add fallback to `aws s3 sync` when FUSE is not available
- document fallback method in README

## Testing
- `bash -n mount_s3.sh`
- `shellcheck mount_s3.sh create_user.sh setup_conda_env.sh`


------
https://chatgpt.com/codex/tasks/task_b_688ca6fa7ef48321974b28f24e1ac95d