### PR TITLE
Fix s3 mount fallback

### DIFF
--- a/mount_s3.sh
+++ b/mount_s3.sh
@@ -27,7 +27,12 @@ fi
 if [[ ! -e /dev/fuse ]]; then
   echo "FUSE device /dev/fuse not found. Falling back to 'aws s3 sync'." >&2
   if ! command -v aws >/dev/null 2>&1; then
-    apt-get update && apt-get install -y --no-install-recommends awscli && rm -rf /var/lib/apt/lists/*
+    if command -v pip >/dev/null 2>&1; then
+      pip install -q awscli
+    else
+      apt-get update && apt-get install -y --no-install-recommends python3-pip && rm -rf /var/lib/apt/lists/*
+      pip install -q awscli
+    fi
   fi
   mkdir -p "$MOUNT_POINT"
   aws s3 sync "s3://$BUCKET" "$MOUNT_POINT" --endpoint-url "$ENDPOINT"


### PR DESCRIPTION
## Summary
- fix the awscli fallback install in `mount_s3.sh`

## Testing
- `bash -n mount_s3.sh`
- `S3_BUCKET=testbucket S3__ACCESS_KEY=foo S3__SECRET_KEY=bar S3__ENDPOINT_URL=http://example.com S3_MOUNT_POINT=/tmp/s3 ./mount_s3.sh`

------
https://chatgpt.com/codex/tasks/task_b_688caa95c88c8321a02bf8f05542e7ca