### PR TITLE
Add multi-user support to startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,14 @@ S3_MOUNT_POINT=
 ADMIN_USER_NAME=
 ADMIN_USER_PUBKEY=
 ADMIN_USER_SUDO=
+ADMIN_USERS=
 GITHUB_TOKEN=
 PYTHON_VERSION=3.12
 ```
+
+`ADMIN_USERS` allows defining multiple users at once using a semicolon separated
+list with the format `username:ssh_key:sudo`. Set `sudo` to `true` to grant the
+user passwordless sudo access.
 
 ### S3 Mount Requirements
 

--- a/extra_commands
+++ b/extra_commands
@@ -51,26 +51,42 @@ fi
 /usr/sbin/sshd -D &
 
 # 2. Создание пользователя и его окружения на основе переменных окружения
-if [ -n "$ADMIN_USER_NAME" ] && [ -n "$ADMIN_USER_PUBKEY" ]; then
+if [ -n "$ADMIN_USERS" ]; then
+    IFS=';' read -ra USER_ENTRIES <<< "$ADMIN_USERS"
+    for ENTRY in "${USER_ENTRIES[@]}"; do
+        IFS=':' read -r USERNAME USERKEY USERSUDO <<< "$ENTRY"
+        [ -z "$USERNAME" ] && continue
+        echo "--- Настройка пользователя $USERNAME ---"
+        KEY_FILE=$(mktemp)
+        echo "$USERKEY" > "$KEY_FILE"
+
+        SUDO_ARG=""
+        if [ "$USERSUDO" = "true" ]; then
+          SUDO_ARG="--sudo"
+        fi
+
+        /opt/scripts/create_user.sh "$USERNAME" "$KEY_FILE" $SUDO_ARG "pod_ip_or_domain"
+        /opt/scripts/setup_conda_env.sh "$USERNAME" "${PYTHON_VERSION:-3.10}"
+        rm "$KEY_FILE"
+        echo "--- Пользователь $USERNAME и его окружение полностью настроены. ---"
+    done
+elif [ -n "$ADMIN_USER_NAME" ] && [ -n "$ADMIN_USER_PUBKEY" ]; then
     echo "--- Настройка пользователя $ADMIN_USER_NAME ---"
     KEY_FILE=$(mktemp)
     echo "$ADMIN_USER_PUBKEY" > "$KEY_FILE"
-    
+
     SUDO_ARG=""
     if [ "$ADMIN_USER_SUDO" = "true" ]; then
       SUDO_ARG="--sudo"
     fi
-    
-    # Шаг 2.1: Создать пользователя
+
     /opt/scripts/create_user.sh "$ADMIN_USER_NAME" "$KEY_FILE" $SUDO_ARG "pod_ip_or_domain"
-    
-    # Шаг 2.2: Создать для него окружение Conda
     /opt/scripts/setup_conda_env.sh "$ADMIN_USER_NAME" "${PYTHON_VERSION:-3.10}"
 
     rm "$KEY_FILE"
     echo "--- Пользователь $ADMIN_USER_NAME и его окружение полностью настроены. ---"
 else
-    echo "Переменные ADMIN_USER_NAME и ADMIN_USER_PUBKEY не заданы. Пользователь не создан."
+    echo "Переменные ADMIN_USER_NAME или ADMIN_USERS не заданы. Пользователь не создан."
 fi
 
 # 3. Attempt to mount S3 storage using provided credentials


### PR DESCRIPTION
## Summary
- support multiple user creation via `ADMIN_USERS`
- update docs for new environment variable

## Testing
- `bash -n extra_commands create_user.sh mount_s3.sh setup_conda_env.sh`
- `shellcheck extra_commands create_user.sh mount_s3.sh setup_conda_env.sh` *(fails: SC2148 SC2289 SC2016)*

------
https://chatgpt.com/codex/tasks/task_b_688cd5b0cf2483219d85d10d38a3133e