### PR TITLE
Add ComfyUI environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository contains pre-configured templates and automation scripts to help
 - Data science stack (Jupyter, pandas, numpy)
 - Web development environment
 - Custom GPU configurations
+- ComfyUI environment setup
 
 ## Contributing
 
@@ -63,11 +64,22 @@ ADMIN_USERS=
 GITHUB_TOKEN=
 PYTHON_VERSION=3.12
 ADMIN_USERS="alice:ssh-ed25519 AAAAB3Nza...:true;bob:ssh-ed25519 AAAAB3Nza...:false"
+COMFY_ENV_NAME=comfy_env
+COMFY_REPO_URL=https://github.com/comfyanonymous/ComfyUI.git
+COMFY_DATA_DIR=/data/marketing
+COMFY_DIR=/data/marketing/comfy
+COMFY_EXTENSION_LIST=comfy_data/extension_list.txt
+COMFY_EXTRA_MODEL_PATHS=comfy_data/extra_model_paths.yaml
 ```
 
 `ADMIN_USERS` allows defining multiple users at once using a semicolon separated
 list with the format `username:ssh_key:sudo`. Set `sudo` to `true` to grant the
 user passwordless sudo access.
+
+The `setup_comfy_env.sh` script installs ComfyUI into `/data/marketing/comfy`,
+installs PyTorch from the official wheel index, clones any extensions listed in
+`comfy_data/extension_list.txt`, and copies `comfy_data/extra_model_paths.yaml`
+to the ComfyUI directory.
 
 ### S3 Mount Requirements
 

--- a/comfy_data/extension_list.txt
+++ b/comfy_data/extension_list.txt
@@ -1,0 +1,4 @@
+# List of ComfyUI extension repositories to install.
+# One URL per line. Lines beginning with '#' are ignored.
+# Example:
+# https://github.com/username/ComfyUI-Custom-Node

--- a/comfy_data/extra_model_paths.yaml
+++ b/comfy_data/extra_model_paths.yaml
@@ -1,0 +1,7 @@
+# Extra model search paths for ComfyUI.
+# Adjust these paths to point to your model directories.
+comfyui:
+  base_path: /data/marketing/models
+  checkpoints: checkpoints
+  loras: loras
+  vae: vae

--- a/create_user.sh
+++ b/create_user.sh
@@ -23,14 +23,21 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
+# Base directory for new user home directories
+USER_BASE_DIR="${USER_BASE_DIR:-/data}"
+
+mkdir -p "$USER_BASE_DIR"
+
 if id "$USERNAME" &>/dev/null; then
   echo "User '$USERNAME' already exists — skipping creation."
 else
-  adduser --disabled-password --gecos "" --shell /bin/bash "$USERNAME"
-  echo "Created user: $USERNAME"
+  # Create the user with a home under /data
+  adduser --disabled-password --gecos "" \
+    --home "${USER_BASE_DIR}/${USERNAME}" --shell /bin/bash "$USERNAME"
+  echo "Created user: $USERNAME at ${USER_BASE_DIR}/${USERNAME}"
 fi
 
-HOME_DIR="/home/${USERNAME}"
+HOME_DIR="${USER_BASE_DIR}/${USERNAME}"
 SSH_DIR="${HOME_DIR}/.ssh"
 
 mkdir -p "$SSH_DIR"


### PR DESCRIPTION
## Summary
- add script to create conda environment for ComfyUI
- document configurable COMFY* variables
- install ComfyUI under `/data/marketing/comfy` with optional extensions and extra model paths
- create users with home directories under `/data` by default

## Testing
- `bash -n setup_comfy_env.sh`
- `bash -n create_user.sh`


------
https://chatgpt.com/codex/tasks/task_b_6890a85a8a8883219796e7cb307c636c